### PR TITLE
v0.2.14 - Custom C++23 source_location for Mac

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -254,6 +254,7 @@ set(UTIL_SOURCE_DIR "${QUARTZ_ROOT_SOURCE_DIR}/util")
 add_subdirectory("${UTIL_SOURCE_DIR}/errors")
 add_subdirectory("${UTIL_SOURCE_DIR}/file_system")
 add_subdirectory("${UTIL_SOURCE_DIR}/logger")
+add_subdirectory("${UTIL_SOURCE_DIR}/source_location")
 add_subdirectory("${UTIL_SOURCE_DIR}/unit_test")
 
 # Quartz

--- a/cmake/QuartzVersion.cmake
+++ b/cmake/QuartzVersion.cmake
@@ -46,5 +46,6 @@ endfunction()
 # set_quartz_major_minor_patch_versions(0 2 10) # physics libarary fixes
 # set_quartz_major_minor_patch_versions(0 2 11) # scene libarary fixes
 # set_quartz_major_minor_patch_versions(0 2 12) # fixes for linux
-set_quartz_major_minor_patch_versions(0 2 13) # RichException implementation and usage
+# set_quartz_major_minor_patch_versions(0 2 13) # RichException implementation and usage
+set_quartz_major_minor_patch_versions(0 2 14) # Custom source_location and mocked stacktrace for Mac so we can still use rich exceptions
 

--- a/src/util/errors/CMakeLists.txt
+++ b/src/util/errors/CMakeLists.txt
@@ -26,8 +26,18 @@ target_compile_definitions(
     ${QUARTZ_COMPILE_DEFINITIONS}
 )
 
+# On mac we do not have access to std::stacktrace and std::source_location,
+# so we are going to provide our own versions instead
+set(STACKTRACE_LIBS "")
+if (CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+    list(APPEND STACKTRACE_LIBS UTIL_SourceLocation)
+else ()
+    list(APPEND STACKTRACE_LIBS stdc++exp)
+endif ()
+
 target_link_libraries(
     UTIL_Errors
+
     PUBLIC
-    stdc++exp # need to set this for std::stacktrace
+    ${STACKTRACE_LIBS}
 )

--- a/src/util/errors/RichException.cpp
+++ b/src/util/errors/RichException.cpp
@@ -1,5 +1,4 @@
 #include <ostream>
-#include <source_location>
 
 #include "util/errors/RichException.hpp"
 
@@ -13,3 +12,4 @@ operator<<(
     os << sourceLocation.function_name();
     return os; 
 }
+

--- a/src/util/errors/RichException.hpp
+++ b/src/util/errors/RichException.hpp
@@ -1,10 +1,26 @@
 #pragma once
 
 #include <ostream>
-#include <source_location>
 #include <sstream>
-#include <stacktrace>
 #include <string>
+
+#include "util/platform.hpp"
+
+#ifdef ON_MAC
+
+#include "util/source_location/SourceLocation.hpp"
+
+namespace std {
+    using source_location = util::SourceLocation;
+    using stacktrace = util::SourceLocation;
+}
+
+#else
+
+#include <source_location>
+#include <stacktrace>
+
+#endif
 
 std::ostream& operator<<(std::ostream& os, const std::source_location& sourceLocation);
 

--- a/src/util/errors/RichException.hpp
+++ b/src/util/errors/RichException.hpp
@@ -12,7 +12,7 @@
 
 namespace std {
     using source_location = util::SourceLocation;
-    using stacktrace = util::SourceLocation;
+    using stacktrace = util::SourceLocation; // Just for the ::current() function to use in logger
 }
 
 #else
@@ -20,9 +20,10 @@ namespace std {
 #include <source_location>
 #include <stacktrace>
 
+std::ostream& operator<<(std::ostream& os, const std::source_location& sourceLocation);
+
 #endif
 
-std::ostream& operator<<(std::ostream& os, const std::source_location& sourceLocation);
 
 namespace util {
     template <typename Data_t>
@@ -78,7 +79,11 @@ operator<<(
 ) {
     os << "What:\n  " << e.what() << "\n";
     os << "Where:\n  " << e.where() << "\n";
+#ifdef ON_MAC
+    os << "Trace:\n  " << "No stacktrace on mac" << "\n";
+#else
     os << "Trace:\n" << e.trace() << "\n";
+#endif
     return os;
 }
 

--- a/src/util/logger/Logger.hpp
+++ b/src/util/logger/Logger.hpp
@@ -330,6 +330,24 @@ std::ostream& operator<<(std::ostream& os, const util::Logger::Level level);
 #define LOG_CRITICALthis(...) \
     util::Logger::critical(this->getLoggerRegistrationInfo().loggerName, __VA_ARGS__)
 
+#ifdef ON_MAC
+#define LOG_THROW(REGISTRATION_NAME, ERROR_TYPE, DATA, ...) \
+    util::Logger::critical(quartz::loggers::REGISTRATION_NAME.loggerName, __VA_ARGS__); \
+    throw ERROR_TYPE( \
+        fmt::format(__VA_ARGS__), \
+        DATA, \
+        std::source_location(__LINE__, 0, __FILE_NAME__, __PRETTY_FUNCTION__), \
+        std::stacktrace::current() \
+    )
+#define LOG_THROWthis(ERROR_TYPE, DATA, ...) \
+    util::Logger::critical(this->getLoggerRegistrationInfo().loggerName, __VA_ARGS__); \
+    throw ERROR_TYPE( \
+        fmt::format(__VA_ARGS__), \
+        DATA, \
+        std::source_location(__LINE__, 0, __FILE_NAME__, __PRETTY_FUNCTION__), \
+        std::stacktrace::current() \
+    )
+#else
 #define LOG_THROW(REGISTRATION_NAME, ERROR_TYPE, DATA, ...) \
     util::Logger::critical(quartz::loggers::REGISTRATION_NAME.loggerName, __VA_ARGS__); \
     throw ERROR_TYPE( \
@@ -346,6 +364,7 @@ std::ostream& operator<<(std::ostream& os, const util::Logger::Level level);
         std::source_location::current(), \
         std::stacktrace::current() \
     )
+#endif
 
 /**
  * @brief Log a scope change

--- a/src/util/source_location/CMakeLists.txt
+++ b/src/util/source_location/CMakeLists.txt
@@ -1,0 +1,26 @@
+#====================================================================
+# The SourceLocation utility library
+#====================================================================
+add_library(
+    UTIL_SourceLocation
+    SHARED
+    SourceLocation.hpp
+    SourceLocation.cpp
+)
+
+target_include_directories(
+    UTIL_SourceLocation
+    PUBLIC
+    ${QUARTZ_INCLUDE_DIRS}
+)
+
+target_compile_options(
+    UTIL_SourceLocation
+    PUBLIC ${QUARTZ_CMAKE_CXX_FLAGS}
+)
+
+target_compile_definitions(
+    UTIL_SourceLocation
+    PUBLIC ${QUARTZ_COMPILE_DEFINITIONS}
+)
+

--- a/src/util/source_location/SourceLocation.cpp
+++ b/src/util/source_location/SourceLocation.cpp
@@ -1,0 +1,15 @@
+#include <ostream>
+
+#include "util/source_location/SourceLocation.hpp"
+
+std::ostream&
+operator<<(
+    std::ostream& os,
+    const util::SourceLocation& sourceLocation
+) {
+    os << sourceLocation.file_name() << " ";
+    os << "(line " << sourceLocation.line() << ") - ";
+    os << sourceLocation.function_name();
+    return os; 
+}
+

--- a/src/util/source_location/SourceLocation.hpp
+++ b/src/util/source_location/SourceLocation.hpp
@@ -1,0 +1,40 @@
+#pragma once
+
+#include <cstdint>
+
+namespace util {
+    class SourceLocation;
+}
+
+/**
+ * @brief A simple implementation of std::source_location so we can still compile
+ *    on mac because mac for some reason cannot use c++23 features
+ *
+ *    This is used in RichException.hpp, where we alias std::source_location to
+ *    this class. They have the same interface.
+ */
+class util::SourceLocation {
+public:
+    static constexpr SourceLocation current() noexcept {
+        return util::SourceLocation();
+    }
+
+    constexpr SourceLocation() noexcept :
+        m_line(0),
+        m_column(0),
+        m_fileName("BoogerFile"),
+        m_functionName("FooberFunction")
+    {}
+
+    constexpr uint32_t line() const noexcept { return m_line; };
+    constexpr uint32_t column() const noexcept { return m_column; };
+    constexpr const char* file_name() const noexcept { return m_fileName; };
+    constexpr const char* function_name() const noexcept { return m_functionName; };
+
+private:
+    uint32_t m_line;
+    uint32_t m_column;
+    const char* m_fileName;
+    const char* m_functionName;
+};
+

--- a/src/util/source_location/SourceLocation.hpp
+++ b/src/util/source_location/SourceLocation.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstdint>
+#include <ostream>
 
 namespace util {
     class SourceLocation;
@@ -15,15 +16,27 @@ namespace util {
  */
 class util::SourceLocation {
 public:
-    static constexpr SourceLocation current() noexcept {
+    static inline constexpr SourceLocation current() noexcept {
         return util::SourceLocation();
     }
 
     constexpr SourceLocation() noexcept :
         m_line(0),
         m_column(0),
-        m_fileName("BoogerFile"),
-        m_functionName("FooberFunction")
+        m_fileName(""),
+        m_functionName("")
+    {}
+
+    constexpr SourceLocation(
+        const uint32_t line,
+        const uint32_t column,
+        const char* fileName,
+        const char* functionName
+    ) noexcept :
+        m_line(line),
+        m_column(column),
+        m_fileName(fileName),
+        m_functionName(functionName)
     {}
 
     constexpr uint32_t line() const noexcept { return m_line; };
@@ -38,3 +51,4 @@ private:
     const char* m_functionName;
 };
 
+std::ostream& operator<<(std::ostream& os, const util::SourceLocation& sourceLocation);

--- a/test/scratch/RichExceptionExample.cpp
+++ b/test/scratch/RichExceptionExample.cpp
@@ -1,6 +1,18 @@
 #include <iostream>
 
+#include "util/logger/Logger.hpp"
 #include "util/errors/RichException.hpp"
+
+DECLARE_LOGGER(THE_LOGGER, trace);
+DECLARE_LOGGER_GROUP(
+    EXCEPTION_TEST,
+    1,
+    THE_LOGGER
+);
+
+// ====================================================================================================
+// Using the exception directly
+// ====================================================================================================
 
 class A_t {
 public:
@@ -38,13 +50,50 @@ void doTheFinalThing() {
     doAnotherThing();
 }
 
+// ====================================================================================================
+// Using the exception via logging macros
+// ====================================================================================================
+
+void loggerthing0() {
+    LOG_FUNCTION_CALL_TRACE(THE_LOGGER, "");
+
+    const A_t theA(69);
+    LOG_THROW(THE_LOGGER, ExceptionA, theA, "Throwing an ExceptionA with an instance of A_t holding 69 from loggerthing()");
+}
+
+void loggerthing1() {
+    LOG_FUNCTION_CALL_TRACE(THE_LOGGER, "");
+    loggerthing0();
+}
+
+void loggerthing2() {
+    LOG_FUNCTION_CALL_TRACE(THE_LOGGER, "");
+    loggerthing1();
+}
+
+void loggerthing3() {
+    LOG_FUNCTION_CALL_TRACE(THE_LOGGER, "");
+    loggerthing2();
+}
+
+// ====================================================================================================
+// Run the main program
+// ====================================================================================================
+
 int main() {
+    REGISTER_LOGGER_GROUP(EXCEPTION_TEST);
+    util::Logger::setLevel("THE_LOGGER", util::Logger::Level::trace);
+
     try {
         doTheFinalThing();
     } catch (ExceptionA& e) {
         std::cout << "Caught exception with data " << e.data().m_value << ":\n" << e << "\n";
+    }
 
-        return 1;
+    try {
+        loggerthing3();
+    } catch (ExceptionA& e) {
+        std::cout << "Caught exception with data " << e.data().m_value << ":\n" << e << "\n";
     }
 
     return 0;


### PR DESCRIPTION
# Description
**What are these changes?**
Implement a custom source_location alternative which we can use on Mac due to lack of c++23 support from apple clang.

**Why are these changes being made?**
We want to enable rich exceptions, but to do so we need C++23 features (source_location and stacktrace) which we cannot get working with apple clang.

###### Related [issues](https://github.com/KingLineSoftworks/Quartz/issues)
**Which issues does this close?**
None

# Testing
**How were these changes tested?**
RichExceptionExample + unit tests

**Have new tests been added?**
No

**How can these changes be tested and validated by the reviewers?**
RichExceptionExample

# Submodules
**Which submodules were effected and why?**
None

# Checklist
- [x] I have commented my changes in complex and hard to understand places
- [x] I have ensured that all existing tests pass
- [ ] I have added tests to cover my changes
- [x] I have incremented the Quartz version appropriately
- [ ] I have merged all upstream submodules
- [x] I have followed the [contribution guidelines](../docs/contributing)
- [ ] I have performed a self review of my changes

