### PR TITLE
v0.3.0 - Scene Debug Mode Entry

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,7 @@
 # ====================================================================
-# Quartz project and version
+# Quartz
 # ====================================================================
+
 set(PROJECT_NAME "Quartz")
 
 cmake_policy(SET CMP0042 NEW)
@@ -36,11 +37,8 @@ if(PROJECT_IS_TOP_LEVEL)
         message(STATUS "CMake binary directory does not contain compile_commands.json file. This is probably the first time running cmake")
     endif ()
 
-    list(
-        APPEND QUARTZ_COMPILE_DEFINITIONS
-        QUARTZ_IS_TOP_LEVEL
-        PROJECT_ROOT_DIR="${CMAKE_CURRENT_SOURCE_DIR}"
-    )
+    list(APPEND QUARTZ_COMPILE_DEFINITIONS QUARTZ_IS_TOP_LEVEL)
+    list(APPEND QUARTZ_COMPILE_DEFINITIONS PROJECT_ROOT_DIR="${CMAKE_CURRENT_SOURCE_DIR}")
 else()
     if(PROJECT_ROOT_DIR)
         message(STATUS "Quartz is not the top level project. PROJECT_ROOT_DIR is defined to ${PROJECT_ROOT_DIR}")
@@ -113,6 +111,7 @@ message(STATUS "Building for ${CMAKE_SYSTEM_NAME}")
 # ====================================================================
 # C++ 23 Support and compiler flags
 # ====================================================================
+
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSTIONS ON)
@@ -135,6 +134,7 @@ endforeach()
 # ====================================================================
 # Third party vendor libraries
 # ====================================================================
+
 set(VENDOR_ROOT_DIR "${PROJECT_SOURCE_DIR}/vendor")
 
 # glfw
@@ -207,6 +207,16 @@ add_library(vulkan SHARED IMPORTED)
 set_target_properties(vulkan PROPERTIES IMPORTED_LOCATION "${VULKAN_LIBRARIES}" INTERFACE_INCLUDE_DIRECTORIES "${VULKAN_INCLUDE_DIRS}")
 
 # ====================================================================
+# Determine whether or not we should enable debug and edit modes
+# ====================================================================
+
+option(QUARTZ_SCENE_DEBUG_MODE_ENABLED "Enable debug information within the scene" TRUE)
+message(STATUS "Quartz debug mode enabled: ${QUARTZ_SCENE_DEBUG_MODE_ENABLED}")
+if (QUARTZ_SCENE_DEBUG_MODE_ENABLED)
+    list(APPEND QUARTZ_COMPILE_DEFINITIONS QUARTZ_SCENE_DEBUG_MODE_ENABLED)
+endif ()
+
+# ====================================================================
 # Define preprocessor directives for the Quartz libraries
 #====================================================================
 
@@ -241,6 +251,7 @@ endforeach()
 # ====================================================================
 # Utility and Quartz libraries
 # ====================================================================
+
 set(QUARTZ_ROOT_SOURCE_DIR "${PROJECT_SOURCE_DIR}/src")
 set(QUARTZ_INCLUDE_DIRS ${QUARTZ_ROOT_SOURCE_DIR})
 
@@ -290,28 +301,17 @@ add_subdirectory("${QUARTZ_SOURCE_DIR}/scene/sky_box")
 #====================================================================
 # The tests
 #====================================================================
+
 include(CTest)
 include(CreateUnitTest)
 include(CreateScratchExecutable)
+
 enable_testing()
+
 set(QUARTZ_TEST_DIR "${PROJECT_SOURCE_DIR}/test")
+
 if (QUARTZ_COMPILE_UNIT_TESTS)
     add_subdirectory("${QUARTZ_TEST_DIR}/unit")
     add_subdirectory("${QUARTZ_TEST_DIR}/scratch")
 endif()
 
-#====================================================================
-# The demo application
-# @brief This is currently commented out because we do not have a demo
-#    application within the Quartz repository. If you wish to see an
-#    up-to-date demo application, check out the PolePosition repo.
-# ====================================================================
-# set(DEMO_APPLICATION_ROOT_DIR "${PROJECT_SOURCE_DIR}/demo_app")
-#
-# set(DEMO_APPLICATION_SOURCE_DIR "${DEMO_APPLICATION_ROOT_DIR}/demo_app")
-# if (QUARTZ_COMPILE_DEMO_APPLICATION)
-#     message(STATUS "Adding Quartz's demo application")
-#     add_subdirectory("${DEMO_APPLICATION_SOURCE_DIR}")
-# else()
-#     message(STATUS "Not adding Quart'z demo application")
-# endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -213,7 +213,9 @@ set_target_properties(vulkan PROPERTIES IMPORTED_LOCATION "${VULKAN_LIBRARIES}" 
 option(QUARTZ_SCENE_DEBUG_MODE_ENABLED "Enable debug information within the scene" TRUE)
 message(STATUS "Quartz debug mode enabled: ${QUARTZ_SCENE_DEBUG_MODE_ENABLED}")
 if (QUARTZ_SCENE_DEBUG_MODE_ENABLED)
-    list(APPEND QUARTZ_COMPILE_DEFINITIONS QUARTZ_SCENE_DEBUG_MODE_ENABLED)
+    list(APPEND QUARTZ_COMPILE_DEFINITIONS QUARTZ_SCENE_DEBUG_MODE_ENABLED=true)
+else ()
+    list(APPEND QUARTZ_COMPILE_DEFINITIONS QUARTZ_SCENE_DEBUG_MODE_ENABLED=false)
 endif ()
 
 # ====================================================================

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -210,12 +210,12 @@ set_target_properties(vulkan PROPERTIES IMPORTED_LOCATION "${VULKAN_LIBRARIES}" 
 # Determine whether or not we should enable debug and edit modes
 # ====================================================================
 
-option(QUARTZ_SCENE_DEBUG_MODE_ENABLED "Enable debug information within the scene" TRUE)
-message(STATUS "Quartz debug mode enabled: ${QUARTZ_SCENE_DEBUG_MODE_ENABLED}")
-if (QUARTZ_SCENE_DEBUG_MODE_ENABLED)
-    list(APPEND QUARTZ_COMPILE_DEFINITIONS QUARTZ_SCENE_DEBUG_MODE_ENABLED=true)
+option(QUARTZ_SCENE_DEBUG_MODE_ALLOWED "Allow the toggling of debug information within the scene" TRUE)
+message(STATUS "Quartz debug mode allowed: ${QUARTZ_SCENE_DEBUG_MODE_ALLOWED}")
+if (QUARTZ_SCENE_DEBUG_MODE_ALLOWED)
+    list(APPEND QUARTZ_COMPILE_DEFINITIONS QUARTZ_SCENE_DEBUG_MODE_ALLOWED=true)
 else ()
-    list(APPEND QUARTZ_COMPILE_DEFINITIONS QUARTZ_SCENE_DEBUG_MODE_ENABLED=false)
+    list(APPEND QUARTZ_COMPILE_DEFINITIONS QUARTZ_SCENE_DEBUG_MODE_ALLOWED=false)
 endif ()
 
 # ====================================================================

--- a/cmake/QuartzVersion.cmake
+++ b/cmake/QuartzVersion.cmake
@@ -47,5 +47,9 @@ endfunction()
 # set_quartz_major_minor_patch_versions(0 2 11) # scene libarary fixes
 # set_quartz_major_minor_patch_versions(0 2 12) # fixes for linux
 # set_quartz_major_minor_patch_versions(0 2 13) # RichException implementation and usage
-set_quartz_major_minor_patch_versions(0 2 14) # Custom source_location and mocked stacktrace for Mac so we can still use rich exceptions
+# set_quartz_major_minor_patch_versions(0 2 14) # Custom source_location and mocked stacktrace for Mac so we can still use rich exceptions
+
+# Minor Version 3 - Scene Debugging Capabilities
+
+set_quartz_major_minor_patch_versions(0 3 0) # Enable Quartz to enter a debugging mode
 

--- a/src/quartz/application/Application.cpp
+++ b/src/quartz/application/Application.cpp
@@ -136,7 +136,7 @@ quartz::Application::processInput() {
         m_inputManager.setShouldCollectKeyInput(!m_isPaused);
     }
 
-#if QUARTZ_SCENE_DEBUG_MODE_ENABLED
+#if QUARTZ_SCENE_DEBUG_MODE_ALLOWED
     if (
         m_inputManager.getKeyInfo_ctrl().down &&
         m_inputManager.getKeyInfo_shift().down &&
@@ -146,13 +146,29 @@ quartz::Application::processInput() {
         LOG_INFOthis("{} scene debug mode", (m_sceneDebugMode ? "Entering" : "Exiting"));
     }
 
-    /**
-     * @todo 2025/09/18 Check if we should toggle debug mode
-     *
-     * @todo 2025/09/18 If debug mode is enabled, check if we should toggle doodad wireframe mode
-     *
-     * @todo 2025/09/18 If debug mode is enabled, check if we should toggle collider wireframe mode
-     */
+    if (!m_sceneDebugMode) {
+        m_wireframeDoodadMode = false;
+        m_wireframeColliderMode = false;
+        return;
+    }
+
+    if (
+        m_inputManager.getKeyInfo_ctrl().down &&
+        m_inputManager.getKeyInfo_shift().down &&
+        m_inputManager.getKeyInfo_l().impacted
+    ) {
+        m_wireframeDoodadMode = !m_wireframeDoodadMode;
+        LOG_INFOthis("{} scene doodad wireframe mode", (m_wireframeDoodadMode ? "Entering" : "Exiting"));
+    }
+
+    if (
+        m_inputManager.getKeyInfo_ctrl().down &&
+        m_inputManager.getKeyInfo_shift().down &&
+        m_inputManager.getKeyInfo_p().impacted
+    ) {
+        m_wireframeColliderMode = !m_wireframeColliderMode;
+        LOG_INFOthis("{} collider wireframe mode", (m_wireframeColliderMode ? "Entering" : "Exiting"));
+    }
 #endif
 }
 

--- a/src/quartz/application/Application.cpp
+++ b/src/quartz/application/Application.cpp
@@ -137,11 +137,21 @@ quartz::Application::processInput() {
     }
 
 #if QUARTZ_SCENE_DEBUG_MODE_ALLOWED
-    if (
-        m_inputManager.getKeyInfo_ctrl().down &&
-        m_inputManager.getKeyInfo_shift().down &&
-        m_inputManager.getKeyInfo_period().impacted
-    ) {
+    const bool super = m_inputManager.getKeyInfo_ctrl().down && m_inputManager.getKeyInfo_shift().down;
+    const bool shouldToggleSceneDebugMode = super && m_inputManager.getKeyInfo_period().impacted;
+    const bool shouldToggleWireframeDoodadMode = super && m_inputManager.getKeyInfo_l().impacted;
+    const bool shouldToggleWireframeColliderMode = super && m_inputManager.getKeyInfo_p().impacted;
+    determineSceneDebugMode(shouldToggleSceneDebugMode, shouldToggleWireframeDoodadMode, shouldToggleWireframeColliderMode);
+#endif
+}
+
+void
+quartz::Application::determineSceneDebugMode(
+    const bool shouldToggleSceneDebugMode,
+    const bool shouldToggleWireframeDoodadMode,
+    const bool shouldToggleWireframeColliderMode
+) {
+    if (shouldToggleSceneDebugMode) {
         m_sceneDebugMode = !m_sceneDebugMode;
         LOG_INFOthis("{} scene debug mode", (m_sceneDebugMode ? "Entering" : "Exiting"));
     }
@@ -152,23 +162,13 @@ quartz::Application::processInput() {
         return;
     }
 
-    if (
-        m_inputManager.getKeyInfo_ctrl().down &&
-        m_inputManager.getKeyInfo_shift().down &&
-        m_inputManager.getKeyInfo_l().impacted
-    ) {
+    if (shouldToggleWireframeDoodadMode) {
         m_wireframeDoodadMode = !m_wireframeDoodadMode;
         LOG_INFOthis("{} scene doodad wireframe mode", (m_wireframeDoodadMode ? "Entering" : "Exiting"));
     }
 
-    if (
-        m_inputManager.getKeyInfo_ctrl().down &&
-        m_inputManager.getKeyInfo_shift().down &&
-        m_inputManager.getKeyInfo_p().impacted
-    ) {
+    if (shouldToggleWireframeColliderMode) {
         m_wireframeColliderMode = !m_wireframeColliderMode;
         LOG_INFOthis("{} collider wireframe mode", (m_wireframeColliderMode ? "Entering" : "Exiting"));
     }
-#endif
 }
-

--- a/src/quartz/application/Application.cpp
+++ b/src/quartz/application/Application.cpp
@@ -37,7 +37,10 @@ quartz::Application::Application(
     m_sceneManager(quartz::managers::SceneManager::Client::getInstance(sceneParameters)),
     m_targetTicksPerSecond(120.0),
     m_shouldQuit(false),
-    m_isPaused(false)
+    m_isPaused(false),
+    m_sceneDebugMode(false),
+    m_wireframeDoodadMode(false),
+    m_wireframeColliderMode(false)
 {
     LOG_FUNCTION_CALL_TRACEthis("");
 }
@@ -132,5 +135,15 @@ quartz::Application::processInput() {
         m_inputManager.setShouldCollectMouseInput(!m_isPaused);
         m_inputManager.setShouldCollectKeyInput(!m_isPaused);
     }
+
+#if QUARTZ_SCENE_DEBUG_MODE_ENABLED
+    /**
+     * @todo 2025/09/18 Check if we should toggle debug mode
+     *
+     * @todo 2025/09/18 If debug mode is enabled, check if we should toggle doodad wireframe mode
+     *
+     * @todo 2025/09/18 If debug mode is enabled, check if we should toggle collider wireframe mode
+     */
+#endif
 }
 

--- a/src/quartz/application/Application.cpp
+++ b/src/quartz/application/Application.cpp
@@ -103,7 +103,7 @@ void quartz::Application::run() {
         double frameInterpolationFactor = (frameTimeAccumulator + targetTickTimeDelta) / targetTickTimeDelta;
 
         currentScene.update(m_renderingContext.getRenderingWindow(), m_inputManager, totalElapsedTime, currentFrameTimeDelta, frameInterpolationFactor);
-        m_renderingContext.draw(currentScene);
+        m_renderingContext.draw(currentScene, m_wireframeDoodadMode, m_wireframeColliderMode);
     }
 
     LOG_INFOthis("Unloading scene");

--- a/src/quartz/application/Application.cpp
+++ b/src/quartz/application/Application.cpp
@@ -124,9 +124,9 @@ void
 quartz::Application::processInput() {
     m_inputManager.collectInput();
 
-    m_shouldQuit = m_renderingContext.getRenderingWindow().shouldClose() || m_inputManager.getKeyDown_q();
+    m_shouldQuit = m_renderingContext.getRenderingWindow().shouldClose() || m_inputManager.getKeyInfo_q().down;
 
-    if (m_inputManager.getKeyImpact_esc()) {
+    if (m_inputManager.getKeyInfo_esc().impacted) {
         m_isPaused = !m_isPaused;
 
         LOG_DEBUGthis("{}ausing", (m_isPaused ? "P" : "Unp"));
@@ -137,6 +137,15 @@ quartz::Application::processInput() {
     }
 
 #if QUARTZ_SCENE_DEBUG_MODE_ENABLED
+    if (
+        m_inputManager.getKeyInfo_ctrl().down &&
+        m_inputManager.getKeyInfo_shift().down &&
+        m_inputManager.getKeyInfo_period().impacted
+    ) {
+        m_sceneDebugMode = !m_sceneDebugMode;
+        LOG_INFOthis("{} scene debug mode", (m_sceneDebugMode ? "Entering" : "Exiting"));
+    }
+
     /**
      * @todo 2025/09/18 Check if we should toggle debug mode
      *

--- a/src/quartz/application/Application.hpp
+++ b/src/quartz/application/Application.hpp
@@ -56,5 +56,9 @@ private: // member variables
     const double m_targetTicksPerSecond;
 
     bool m_shouldQuit;
-    bool m_isPaused;
+    bool m_isPaused; /** @todo 2025/09/18 Get rid of this - this should be implemented in the client */
+
+    UNUSED bool m_sceneDebugMode;
+    UNUSED bool m_wireframeDoodadMode;
+    UNUSED bool m_wireframeColliderMode;
 };

--- a/src/quartz/application/Application.hpp
+++ b/src/quartz/application/Application.hpp
@@ -11,8 +11,14 @@
 #include "quartz/scene/scene/Scene.hpp"
 
 namespace quartz {
-    class Application;
+
+class Application;
+
+namespace unit_test {
+    class ApplicationUnitTestClient;
 }
+
+} // namespace Quartz
 
 class quartz::Application {
 public: // member functions
@@ -35,10 +41,19 @@ public: // member functions
 
     USE_LOGGER(APPLICATION);
 
+    bool getSceneDebugMode() const { return m_sceneDebugMode; }
+    bool getWireframeDoodadMode() const { return m_wireframeDoodadMode; }
+    bool getWireframeColliderMode() const { return m_wireframeColliderMode; }
+
     void run();
 
 private: // member functions
     void processInput();
+    void determineSceneDebugMode(
+        const bool shouldToggleSceneDebugMode,
+        const bool shouldToggleWireframeDoodadMode,
+        const bool shouldToggleWireframeColliderMode
+    );
 
 private: // static functions
 
@@ -61,4 +76,8 @@ private: // member variables
     bool m_sceneDebugMode;
     bool m_wireframeDoodadMode;
     bool m_wireframeColliderMode;
+
+private: // friends
+    friend class quartz::unit_test::ApplicationUnitTestClient;
 };
+

--- a/src/quartz/application/Application.hpp
+++ b/src/quartz/application/Application.hpp
@@ -58,7 +58,7 @@ private: // member variables
     bool m_shouldQuit;
     bool m_isPaused; /** @todo 2025/09/18 Get rid of this - this should be implemented in the client */
 
-    UNUSED bool m_sceneDebugMode;
-    UNUSED bool m_wireframeDoodadMode;
-    UNUSED bool m_wireframeColliderMode;
+    bool m_sceneDebugMode;
+    bool m_wireframeDoodadMode;
+    bool m_wireframeColliderMode;
 };

--- a/src/quartz/managers/input_manager/InputManager.cpp
+++ b/src/quartz/managers/input_manager/InputManager.cpp
@@ -15,17 +15,21 @@ quartz::managers::InputManager::InputManager(
 
     m_shouldCollectKeyInput(true),
 
-    m_keyDown_q(false),
-    m_keyImpact_q(false),
-    m_keyDown_esc(false),
-    m_keyImpact_esc(false),
+    m_a(false, false, false),
+    m_d(false, false, false),
+    m_l(false, false, false),
+    m_p(false, false, false),
+    m_q(false, false, false),
+    m_s(false, false, false),
+    m_w(false, false, false),
 
-    m_keyDown_w(false),
-    m_keyDown_a(false),
-    m_keyDown_s(false),
-    m_keyDown_d(false),
-    m_keyDown_space(false),
-    m_keyDown_shift(false),
+    m_esc(false, false, false),
+    m_shift(false, false, false),
+    m_ctrl(false, false, false),
+    m_space(false, false, false),
+
+    m_period(false, false, false),
+
 
     m_mousePosition_x(0.0f),
     m_mousePosition_y(0.0f),
@@ -48,17 +52,20 @@ quartz::managers::InputManager::InputManager(
 
     m_shouldCollectKeyInput(other.m_shouldCollectKeyInput),
 
-    m_keyDown_q(other.m_keyDown_q),
-    m_keyImpact_q(other.m_keyImpact_q),
-    m_keyDown_esc(other.m_keyDown_esc),
-    m_keyImpact_esc(other.m_keyImpact_esc),
+    m_a(other.m_a),
+    m_d(other.m_d),
+    m_l(other.m_l),
+    m_p(other.m_p),
+    m_q(other.m_q),
+    m_s(other.m_s),
+    m_w(other.m_w),
 
-    m_keyDown_w(other.m_keyDown_w),
-    m_keyDown_a(other.m_keyDown_a),
-    m_keyDown_s(other.m_keyDown_s),
-    m_keyDown_d(other.m_keyDown_d),
-    m_keyDown_space(other.m_keyDown_space),
-    m_keyDown_shift(other.m_keyDown_shift),
+    m_esc(other.m_esc),
+    m_shift(other.m_shift),
+    m_ctrl(other.m_ctrl),
+    m_space(other.m_space),
+
+    m_period(other.m_period),
 
     m_mousePosition_x(other.m_mousePosition_x),
     m_mousePosition_y(other.m_mousePosition_y),
@@ -79,22 +86,25 @@ quartz::managers::InputManager::collectInput() {
 
     glfwPollEvents();
 
-    m_keyDown_q = glfwGetKey(mp_glfwWindow.get(), GLFW_KEY_Q);
-
-    bool keyDown_esc = glfwGetKey(mp_glfwWindow.get(), GLFW_KEY_ESCAPE);
-    m_keyImpact_esc = keyDown_esc && !m_keyDown_esc;
-    m_keyDown_esc = keyDown_esc;
+    m_esc = getKeyPressInfo(m_w.down, GLFW_KEY_ESCAPE);
+    m_q = getKeyPressInfo(m_q.down, GLFW_KEY_Q);
 
     if (!m_shouldCollectKeyInput) {
         return;
     }
 
-    m_keyDown_w = glfwGetKey(mp_glfwWindow.get(), GLFW_KEY_W);
-    m_keyDown_a = glfwGetKey(mp_glfwWindow.get(), GLFW_KEY_A);
-    m_keyDown_s = glfwGetKey(mp_glfwWindow.get(), GLFW_KEY_S);
-    m_keyDown_d = glfwGetKey(mp_glfwWindow.get(), GLFW_KEY_D);
-    m_keyDown_space = glfwGetKey(mp_glfwWindow.get(), GLFW_KEY_SPACE);
-    m_keyDown_shift = glfwGetKey(mp_glfwWindow.get(), GLFW_KEY_LEFT_SHIFT);
+    m_a = getKeyPressInfo(m_a.down, GLFW_KEY_A);
+    m_d = getKeyPressInfo(m_d.down, GLFW_KEY_D);
+    m_l = getKeyPressInfo(m_l.down, GLFW_KEY_L);
+    m_p = getKeyPressInfo(m_p.down, GLFW_KEY_P);
+    m_s = getKeyPressInfo(m_s.down, GLFW_KEY_S);
+    m_w = getKeyPressInfo(m_w.down, GLFW_KEY_W);
+
+    m_shift = getKeyPressInfo(m_shift.down, GLFW_KEY_LEFT_SHIFT);
+    m_ctrl = getKeyPressInfo(m_ctrl.down, GLFW_KEY_LEFT_CONTROL);
+    m_space = getKeyPressInfo(m_space.down, GLFW_KEY_SPACE);
+
+    m_period = getKeyPressInfo(m_period.down, GLFW_KEY_PERIOD);
 }
 
 void
@@ -110,6 +120,18 @@ quartz::managers::InputManager::setShouldCollectKeyInput(const bool shouldCollec
     m_shouldCollectKeyInput = shouldCollect;
 
     LOG_DEBUGthis("{} mouse input", (m_shouldCollectKeyInput ? "Enabling" : "Disabling"));
+}
+
+quartz::managers::InputManager::KeyPressInfo
+quartz::managers::InputManager::getKeyPressInfo(
+    const bool currentDown,
+    const int glfwKey
+) {
+    const bool keyDown = glfwGetKey(mp_glfwWindow.get(), glfwKey);
+    const bool keyImpacted = keyDown && !currentDown;
+    const bool keyReleased = !keyDown && currentDown;
+
+    return quartz::managers::InputManager::KeyPressInfo(keyDown, keyImpacted, keyReleased);
 }
 
 quartz::managers::InputManager&

--- a/src/quartz/managers/input_manager/InputManager.cpp
+++ b/src/quartz/managers/input_manager/InputManager.cpp
@@ -79,9 +79,8 @@ quartz::managers::InputManager::collectInput() {
 
     glfwPollEvents();
 
-    bool keyDown_q = glfwGetKey(mp_glfwWindow.get(), GLFW_KEY_Q);
-    m_keyDown_q = keyDown_q && !m_keyDown_q;
-    m_keyDown_q = keyDown_q;
+    m_keyDown_q = glfwGetKey(mp_glfwWindow.get(), GLFW_KEY_Q);
+
     bool keyDown_esc = glfwGetKey(mp_glfwWindow.get(), GLFW_KEY_ESCAPE);
     m_keyImpact_esc = keyDown_esc && !m_keyDown_esc;
     m_keyDown_esc = keyDown_esc;

--- a/src/quartz/managers/input_manager/InputManager.hpp
+++ b/src/quartz/managers/input_manager/InputManager.hpp
@@ -23,6 +23,12 @@ namespace unit_test {
 
 class quartz::managers::InputManager {
 public: // classes
+    struct KeyPressInfo {
+        bool down;
+        bool impacted;
+        bool released;
+    };
+
     class Client {
     public: // member functions
         Client() = delete;
@@ -44,17 +50,20 @@ public: // member functions
 
     void collectInput();
 
-    bool getKeyDown_q() const { return m_keyDown_q; }
-    bool getKeyImpact_q() const { return m_keyImpact_q; }
-    bool getKeyDown_esc() const { return m_keyDown_esc; }
-    bool getKeyImpact_esc() const { return m_keyImpact_esc; }
+    const KeyPressInfo& getKeyInfo_a() const { return m_a; }
+    const KeyPressInfo& getKeyInfo_d() const { return m_d; }
+    const KeyPressInfo& getKeyInfo_l() const { return m_l; }
+    const KeyPressInfo& getKeyInfo_p() const { return m_p; }
+    const KeyPressInfo& getKeyInfo_q() const { return m_q; }
+    const KeyPressInfo& getKeyInfo_s() const { return m_s; }
+    const KeyPressInfo& getKeyInfo_w() const { return m_w; }
 
-    bool getKeyDown_w() const { return m_keyDown_w; }
-    bool getKeyDown_a() const { return m_keyDown_a; }
-    bool getKeyDown_s() const { return m_keyDown_s; }
-    bool getKeyDown_d() const { return m_keyDown_d; }
-    bool getKeyDown_space() const { return m_keyDown_space; }
-    bool getKeyDown_shift() const { return m_keyDown_shift; }
+    const KeyPressInfo& getKeyInfo_esc() const { return m_esc; }
+    const KeyPressInfo& getKeyInfo_shift() const { return m_shift; }
+    const KeyPressInfo& getKeyInfo_ctrl() const { return m_ctrl; }
+    const KeyPressInfo& getKeyInfo_space() const { return m_space; }
+
+    const KeyPressInfo& getKeyInfo_period() const { return m_period; }
 
     float getMousePosition_x() const { return m_mousePosition_x; }
     float getMousePosition_y() const { return m_mousePosition_y; }
@@ -80,6 +89,7 @@ public: // static functions
     );
 
 private: // member functions
+    KeyPressInfo  getKeyPressInfo(const bool currentDown, const int glfwKey);
     static InputManager& getInstance(const std::shared_ptr<GLFWwindow>& p_glfwWindow);
 
 private: // member functions
@@ -96,17 +106,20 @@ private: // member variables
 
     bool m_shouldCollectKeyInput;
 
-    bool m_keyDown_q;
-    bool m_keyImpact_q;
-    bool m_keyDown_esc;
-    bool m_keyImpact_esc;
+    KeyPressInfo m_a;
+    KeyPressInfo m_d;
+    KeyPressInfo m_l;
+    KeyPressInfo m_p;
+    KeyPressInfo m_q;
+    KeyPressInfo m_s;
+    KeyPressInfo m_w;
 
-    bool m_keyDown_w;
-    bool m_keyDown_a;
-    bool m_keyDown_s;
-    bool m_keyDown_d;
-    bool m_keyDown_space;
-    bool m_keyDown_shift;
+    KeyPressInfo m_esc;
+    KeyPressInfo m_shift;
+    KeyPressInfo m_ctrl;
+    KeyPressInfo m_space;
+
+    KeyPressInfo m_period;
 
     float m_mousePosition_x;
     float m_mousePosition_y;

--- a/src/quartz/rendering/context/Context.hpp
+++ b/src/quartz/rendering/context/Context.hpp
@@ -44,7 +44,11 @@ public: // member functions
 
     void loadScene(const quartz::scene::Scene& scene);
 
-    void draw(const quartz::scene::Scene& scene);
+    void draw(
+        const quartz::scene::Scene& scene,
+        const bool wireframeDoodadMode,
+        const bool wireframeColliderMode
+    );
     void finish();
 
 private: // static functions
@@ -63,6 +67,16 @@ private: // static functions
 
 private: // member functions
     void recreateSwapchain();
+    void updateSkyBoxPipeline(
+        const quartz::scene::Scene& scene,
+        quartz::scene::Camera::UniformBufferObject& cameraUBO
+    );
+    void updateDoodadPipeline(
+        const quartz::scene::Scene& scene,
+        quartz::scene::Camera::UniformBufferObject& cameraUBO
+    );
+    void recordSkyBoxPipeline(const quartz::scene::Scene& scene);
+    void recordDoodadPipeline(const quartz::scene::Scene& scene);
 
 private: // member variables
     const uint32_t m_maxNumFramesInFlight;

--- a/src/quartz/rendering/context/Context.hpp
+++ b/src/quartz/rendering/context/Context.hpp
@@ -67,16 +67,16 @@ private: // static functions
 
 private: // member functions
     void recreateSwapchain();
-    void updateSkyBoxPipeline(
-        const quartz::scene::Scene& scene,
-        quartz::scene::Camera::UniformBufferObject& cameraUBO
-    );
+    void waitForImage();
+    void updateSkyBoxPipeline( const quartz::scene::Camera::UniformBufferObject& cameraUBO);
     void updateDoodadPipeline(
         const quartz::scene::Scene& scene,
-        quartz::scene::Camera::UniformBufferObject& cameraUBO
+        const quartz::scene::Camera::UniformBufferObject& cameraUBO
     );
+    void resetSwapchain(const uint32_t availableSwapchainImageIndex);
     void recordSkyBoxPipeline(const quartz::scene::Scene& scene);
     void recordDoodadPipeline(const quartz::scene::Scene& scene);
+    void submitImage(const uint32_t availableSwapchainImageIndex);
 
 private: // member variables
     const uint32_t m_maxNumFramesInFlight;

--- a/src/quartz/rendering/pipeline/Pipeline.cpp
+++ b/src/quartz/rendering/pipeline/Pipeline.cpp
@@ -925,7 +925,7 @@ void
 quartz::rendering::Pipeline::updateUniformBuffer(
     const uint32_t currentInFlightFrameIndex,
     const uint32_t uniformIndex,
-    void* p_dataToCopy
+    const void* p_dataToCopy
 ) {
     const quartz::rendering::UniformBufferInfo& uniformBufferInfo = m_uniformBufferInfos[uniformIndex];
 

--- a/src/quartz/rendering/pipeline/Pipeline.hpp
+++ b/src/quartz/rendering/pipeline/Pipeline.hpp
@@ -90,7 +90,7 @@ public: // member functions
     void updateUniformBuffer(
         const uint32_t currentInFlightFrameIndex,
         const uint32_t uniformIndex,
-        void* p_dataToCopy
+        const void* p_dataToCopy
     );
 
 private: // static functions

--- a/src/util/macros.hpp
+++ b/src/util/macros.hpp
@@ -127,6 +127,14 @@
 #endif
 
 /**
+ * @brief Make sure the scene debug mode definition is present for linting purposes
+ */
+
+#ifndef QUARTZ_SCENE_DEBUG_MODE_ENABLED
+#define QUARTZ_SCENE_DEBUG_MODE_ENABLED false
+#endif
+
+/**
  * @brief Macros determining the quanitity of things we can have in a scene. These
  * should be defined at compile time by cmake. If these aren't defined for us at
  * compile time then we should set these to values that should invoke errors
@@ -147,3 +155,4 @@
 #ifndef QUARTZ_MAX_NUMBER_SPOT_LIGHTS
 #define QUARTZ_MAX_NUMBER_SPOT_LIGHTS -1
 #endif
+

--- a/src/util/macros.hpp
+++ b/src/util/macros.hpp
@@ -130,8 +130,8 @@
  * @brief Make sure the scene debug mode definition is present for linting purposes
  */
 
-#ifndef QUARTZ_SCENE_DEBUG_MODE_ENABLED
-#define QUARTZ_SCENE_DEBUG_MODE_ENABLED false
+#ifndef QUARTZ_SCENE_DEBUG_MODE_ALLOWED
+#define QUARTZ_SCENE_DEBUG_MODE_ALLOWED false
 #endif
 
 /**

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -22,6 +22,8 @@ add_subdirectory("util/logger")
 # Quartz unit tests
 #====================================================================
 
+add_subdirectory("quartz/application")
+
 add_subdirectory("quartz/physics/collider")
 add_subdirectory("quartz/physics/field")
 add_subdirectory("quartz/physics/rigid_body")

--- a/test/unit/quartz/application/CMakeLists.txt
+++ b/test/unit/quartz/application/CMakeLists.txt
@@ -1,0 +1,6 @@
+#====================================================================
+# Quartz Application Unit Tests
+#====================================================================
+
+create_unit_test(test_Application.cpp QUARTZ_Application)
+

--- a/test/unit/quartz/application/test_Application.cpp
+++ b/test/unit/quartz/application/test_Application.cpp
@@ -1,0 +1,88 @@
+#include "util/unit_test/UnitTest.hpp"
+
+#include "quartz/application/Application.hpp"
+
+namespace quartz {
+namespace unit_test {
+
+class ApplicationUnitTestClient {
+public:
+    static void determineSceneDebugMode(
+        quartz::Application& application,
+        const bool shouldToggleSceneDebugMode,
+        const bool shouldToggleWireframeDoodadMode,
+        const bool shouldToggleWireframeColliderMode
+    ) {
+        application.determineSceneDebugMode(
+            shouldToggleSceneDebugMode,
+            shouldToggleWireframeDoodadMode,
+            shouldToggleWireframeColliderMode
+        );
+    }
+
+private:
+    ApplicationUnitTestClient() = delete;
+};
+
+} // namespace unit_test
+} // namespace quartz
+
+UT_FUNCTION(test_determineSceneDebugMode) {
+    quartz::Application application(
+        "test_determineSceneDebugMode",
+        0,
+        0,
+        0,
+        100,
+        100,
+        false,
+        {}
+    );
+
+    // Don't toggle anything
+    quartz::unit_test::ApplicationUnitTestClient::determineSceneDebugMode(application, false, false, false);
+    UT_CHECK_FALSE(application.getSceneDebugMode());
+    UT_CHECK_FALSE(application.getWireframeDoodadMode());
+    UT_CHECK_FALSE(application.getWireframeColliderMode());
+
+    // Toggle debug mode
+    quartz::unit_test::ApplicationUnitTestClient::determineSceneDebugMode(application, true, false, false);
+    UT_CHECK_TRUE(application.getSceneDebugMode());
+    UT_CHECK_FALSE(application.getWireframeDoodadMode());
+    UT_CHECK_FALSE(application.getWireframeColliderMode());
+
+    // Toggle wire frame doodad mode
+    quartz::unit_test::ApplicationUnitTestClient::determineSceneDebugMode(application, false, true, false);
+    UT_CHECK_TRUE(application.getSceneDebugMode());
+    UT_CHECK_TRUE(application.getWireframeDoodadMode());
+    UT_CHECK_FALSE(application.getWireframeColliderMode());
+
+    // Toggle both wire frame modes - doodad should be off, collider on
+    quartz::unit_test::ApplicationUnitTestClient::determineSceneDebugMode(application, false, true, true);
+    UT_CHECK_TRUE(application.getSceneDebugMode());
+    UT_CHECK_FALSE(application.getWireframeDoodadMode());
+    UT_CHECK_TRUE(application.getWireframeColliderMode());
+
+    // Toggle wire frame collider mode - only debug mode should be on
+    quartz::unit_test::ApplicationUnitTestClient::determineSceneDebugMode(application, false, false, true);
+    UT_CHECK_TRUE(application.getSceneDebugMode());
+    UT_CHECK_FALSE(application.getWireframeDoodadMode());
+    UT_CHECK_FALSE(application.getWireframeColliderMode());
+
+    // Toggle both wire frame modes - everything should be on now
+    quartz::unit_test::ApplicationUnitTestClient::determineSceneDebugMode(application, false, true, true);
+    UT_CHECK_TRUE(application.getSceneDebugMode());
+    UT_CHECK_TRUE(application.getWireframeDoodadMode());
+    UT_CHECK_TRUE(application.getWireframeColliderMode());
+
+    // Toggle debug mode - so the other two should turn off
+    quartz::unit_test::ApplicationUnitTestClient::determineSceneDebugMode(application, true, false, false);
+    UT_CHECK_FALSE(application.getSceneDebugMode());
+    UT_CHECK_FALSE(application.getWireframeDoodadMode());
+    UT_CHECK_FALSE(application.getWireframeColliderMode());
+}
+
+UT_MAIN() {
+    REGISTER_UT_FUNCTION(test_determineSceneDebugMode);
+    UT_RUN_TESTS();
+}


### PR DESCRIPTION
# Description
**What are these changes?**
Implement the ability for Quartz to enter the scene debugging mode if it is allowed. This can be disallowed via cmake arguments.

Rework the way the InputManager reports keypresses.

Clean up some of the Context's draw functionality.

**Why are these changes being made?**
This will allow us to enable features to debug information within a scene (ui elements which are not yet implemented), and turn on different rendering modes to debug meshes and colliders.

We want to allow/disallow these features at compile time for when we are shipping something. Of course, when we ship the game we don't want people to enter debug mode.

The InputManager is now featured to make it much easier to implement new keypresses and determine if a key is impacted or released this frame.

We want to rework the way the context is structured so we can implement wireframe modes more easily.

###### Related [issues](https://github.com/KingLineSoftworks/Quartz/issues)
**Which issues does this close?**
- closes #147 

# Testing
**How were these changes tested?**
Tested with our PolePosition demo application and the unit tests in both debug and release mode.

**Have new tests been added?**
Yes, `test_Application.cpp` for the Application's debug mode logic.

**How can these changes be tested and validated by the reviewers?**
Unit tests, demo application

# Submodules
**Which submodules were effected and why?**
None

# Checklist
- [x] I have commented my changes in complex and hard to understand places
- [x] I have ensured that all existing tests pass
- [x] I have added tests to cover my changes
- [x] I have incremented the Quartz version appropriately
- [ ] I have merged all upstream submodules
- [x] I have followed the [contribution guidelines](../docs/contributing)
- [ ] I have performed a self review of my changes

